### PR TITLE
chore: Refactor KhipuPay initialization method

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,10 +5,7 @@ import 'package:khipu_pay_plugin/khipu_pay_plugin.dart';
 import 'widget/ticket_card.dart';
 
 void main() {
-  KhipuPay.initialize(
-    keyMode: KeyMode.normal,
-    apiKey: 'your_api_key',
-  );
+  KhipuPay.initialize(apiKey: 'your_api_key');
   runApp(const MyApp());
 }
 

--- a/lib/khipu_pay_plugin.dart
+++ b/lib/khipu_pay_plugin.dart
@@ -4,7 +4,6 @@
 library khipupay_plugin;
 
 export 'src/khipu_pay.dart';
-export 'src/config/key_mode.dart';
 export 'src/domain/khipu_result.dart';
 export 'src/domain/khipu_payment.dart';
 export 'src/domain/khipu_payment_form.dart';

--- a/lib/src/config/key_mode.dart
+++ b/lib/src/config/key_mode.dart
@@ -1,6 +1,0 @@
-/// Represents the mode for the key.
-///
-/// The `KeyMode` enum is used to specify the mode for the key. It has two possible values:
-/// - `normal`: Represents the normal mode for the key.
-/// - `dartDefine`: Represents the mode for defining the key in Dart.
-enum KeyMode { normal, dartDefine }

--- a/lib/src/khipu_pay.dart
+++ b/lib/src/khipu_pay.dart
@@ -31,32 +31,22 @@ final class KhipuPay {
   /// KhipuPay.initialize();
   ///
   /// Note: This method should be called only once during the app's lifecycle.
-  static void initialize({
-    KeyMode keyMode = KeyMode.dartDefine,
-    String? apiKey,
-  }) {
+  static void initialize({String? apiKey}) {
     assert(
       !_instance._initialized,
       'This instance is already initialized',
     );
 
-    switch (keyMode) {
-      case KeyMode.normal:
-        if (apiKey == null || apiKey.isEmpty) {
-          throw ArgumentError(
-              'You must provide an API key when using KeyMode.normal');
-        }
-        _instance._init(apiKey);
-      case KeyMode.dartDefine:
-        const apiKey = String.fromEnvironment(Constants.khipuAPIKey,
-            defaultValue: Constants.empty);
+    if (apiKey != null && apiKey.isNotEmpty) {
+      _instance._init(apiKey);
+    } else {
+      const apiKey = String.fromEnvironment(Constants.khipuAPIKey, defaultValue: Constants.empty);
 
-        if (apiKey.isEmpty) {
-          throw ArgumentError(
-              'You must provide an API key when using KeyMode.dartDefine');
-        }
+      if (apiKey.isEmpty) {
+        throw ArgumentError('You must provide an API key in the environment variables or as a parameter to initialize() method.');
+      }
 
-        _instance._init(apiKey);
+      _instance._init(apiKey);
     }
   }
 


### PR DESCRIPTION
The KhipuPay initialization method has been refactored to simplify the code and improve readability. The `KeyMode` parameter has been removed, and the `apiKey` parameter is now optional. If an `apiKey` is provided, it will be used to initialize the instance. Otherwise, the `apiKey` will be retrieved from the environment variables. If no `apiKey` is found, an error will be thrown.