### PR TITLE
"Refactor KhipuPay initialization and processPayment methods"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Documentation update.
 * Process Payment without initialize the library.
+* KeyMode removed.
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+# Changelog
+
+## 2.0.1
+
+* Documentation update.
+* Process Payment without initialize the library.
+
 ## 2.0.0
+
 * Project restructuring
 * Web support
 * Version of khenshin 1.756

--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,7 @@
 
 [Español](README.md) | English
 
-KhipuPay is a library that allows you to integrate Khipu payments into your Flutter app.
+KhipuPay is a library that allows you to integrate Khipu payments in your Flutter app.
 
 ## Example
 
@@ -14,22 +14,23 @@ import 'package:khipu_pay_plugin/khipu_pay_plugin.dart';
 
 ### Initialize
 
-There are two ways to instance the library, we recommend using the first one, because take the apiKey value from the environment variables.
+There are two ways to instantiate the library, we recommend using the first one, because it takes the apiKey value from the environment variables.
 
-This is the best approach because it allows you to keep your API key secure and not expose it in the code.
+This is the best approach, as it allows you to keep your API key safe and not expose it in the code.
 
 ```dart
 KhipuPay.initialize();
 ```
 
-The second way is to pass the keyMode and apiKey values directly to the initialize method.
+The second way is to pass the apiKey directly to the initialize method.
 
-```dart
+````dart
 KhipuPay.initialize(
-  keyMode: KeyMode.normal,
   apiKey: 'your_api_key',
 );
 ```
+
+**IMPORTANT:** To process a payment it is not necessary to initialize the library, since the Khipu API calls can be made from the backend. So it is only necessary to initialize the library if you want to make Khipu API calls from the frontend.
 
 ### Create Payment
 
@@ -52,7 +53,7 @@ KhipuPayment khipuPayment = await KhipuPay.instance.createPayment(
 To process a payment, you need to call the `processPayment` method and pass a `paymentId` as a parameter, obtained from the `createPayment` method. The `processPayment` method will return a `KhipuResult` object.
 
 ```dart
-KhipuResult? result = await KhipuPay.instance.processPayment(paymentId: 'your_payment_id');
+KhipuResult? result = await KhipuPay.processPayment(paymentId: 'your_payment_id');
 ```
 
 ### Check Status Payment
@@ -74,17 +75,18 @@ We recommend using the following version: `https\://services.gradle.org/distribu
 In the `build.gradle` file, change the `com.android.tools.build:gradle` version to the latest version compatible with the Gradle version in this case `8.3.2`.
 
 #### iOS
+
 Remove use_frameworks! of Podfile, to avoid conflicts with Khipu library
 
-```
+```ruby
 target 'Runner' do
   use_frameworks!
 ```
 
 ## Important
+
 * This library is not official, it was created to facilitate the integration of Khipu payments into Flutter apps.
 * Khipu provide an apiKey for development and production environment, you must change these fields, depending on the environment in which your application is located, so that you can process your payments correctly.
-
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Este es el mejor enfoque, ya que le permite mantener su clave de API segura y no
 KhipuPay.initialize();
 ```
 
-La segunda forma es pasar los valores keyMode y apiKey directamente al método initialize.
+La segunda forma es pasar el apiKey directamente al método initialize.
 
 ```dart
 KhipuPay.initialize(
-  keyMode: KeyMode.normal,
   apiKey: 'your_api_key',
 );
 ```
+
+**IMPORTANTE:** Para procesar un pago no es necesario inicializar la libreria, ya que las llamadas a la API de Khipu se pueden hacer desde el backend. Por lo que solo es necesario inicializar la librería si se desea hacer llamadas a la API de Khipu desde el frontend.
 
 ### Create Payment
 
@@ -52,7 +53,7 @@ KhipuPayment khipuPayment = await KhipuPay.instance.createPayment(
 Para procesar un pago, es necesario llamar al método `processPayment` y pasar un `paymentId` como parámetro, obtenido del método `createPayment`. El método `processPayment` devolverá un objeto `KhipuResult`.
 
 ```dart
-KhipuResult? result = await KhipuPay.instance.processPayment(paymentId: 'your_payment_id');
+KhipuResult? result = await KhipuPay.processPayment(paymentId: 'your_payment_id');
 ```
 
 ### Comprobar el estado del pago
@@ -74,17 +75,18 @@ Recomendamos utilizar la siguiente versión: `https\://services.gradle.org/distr
 En el archivo `build.gradle`, cambia la versión `com.android.tools.build:gradle` por la última versión compatible con la versión de Gradle en este caso `8.3.2`.
 
 #### iOS
+
 Eliminar use_frameworks! de Podfile, para evitar conflictos con la librería Khipu
 
-```
+```ruby
 target 'Runner' do
   use_frameworks!
 ```
 
 ## Importante
+
 * Esta librería no es oficial, fue creada para facilitar la integración de pagos Khipu en apps Flutter.
 * Khipu proporciona una apiKey para entorno de desarrollo y producción, debes cambiar estos campos, dependiendo del entorno en el que se encuentre tu aplicación, para que puedas procesar tus pagos correctamente.
-
 
 ## Referencias
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: khipu_pay_plugin
 description: "Plugin to create payment identifiers, process payments and verify the status of a payment through the Khipu Platform."
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/juanvegu/khipu_pay_plugin
 
 environment:


### PR DESCRIPTION
The KhipuPay initialization method has been refactored to simplify the code and improve readability. The `KeyMode` parameter has been removed, and the `apiKey` parameter is now optional. If an `apiKey` is provided, it will be used to initialize the instance. Otherwise, the `apiKey` will be retrieved from the environment variables. If no `apiKey` is found, an error will be thrown.

The KhipuPay processPayment method has also been refactored to use static. This change improves the efficiency and performance of the method.